### PR TITLE
Bugfix: `CleanAddin` task locks the assembly file so the build fails

### DIFF
--- a/src/AssemblyEx.cs
+++ b/src/AssemblyEx.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace NetOffice.Build
@@ -14,6 +16,45 @@ namespace NetOffice.Build
         {
             path = path.Replace('\\', '/');
             return $"file:///{path}";
+        }
+
+        internal static Assembly ReflectionOnlyLoadAssembly(string path)
+        {
+            if (File.Exists(path))
+            {
+                var assemblyName = AssemblyName.GetAssemblyName(path);
+                var assemblies = AppDomain.CurrentDomain.ReflectionOnlyGetAssemblies();
+                var existing = assemblies.FirstOrDefault(assembly => assembly.FullName == assemblyName.FullName);
+                if (existing != null)
+                {
+                    return existing;
+                }
+
+                var content = File.ReadAllBytes(path);
+                return Assembly.ReflectionOnlyLoad(content);
+            }
+
+            return null;
+        }
+
+        internal static Assembly ReflectionOnlyAssemblyResolve(ResolveEventArgs args, string baseDir)
+        {
+            Console.WriteLine($"Assembly: {args?.Name} by {args?.RequestingAssembly?.GetName()}");
+
+            var name = new AssemblyName(args.Name);
+            var path = Path.Combine(baseDir, name.Name + ".dll");
+            Assembly assembly = null;
+            if (File.Exists(path))
+            {
+                assembly = ReflectionOnlyLoadAssembly(path);
+            }
+            else
+            {
+                // Log.LogWarning($"Loading assembly by name '{args.Name}'.");
+                assembly = Assembly.ReflectionOnlyLoad(args.Name);
+            }
+
+            return assembly;
         }
     }
 }

--- a/src/CleanAddin.cs
+++ b/src/CleanAddin.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -17,11 +15,10 @@ namespace NetOffice.Build
         {
             try
             {
-                var assembly = Assembly.LoadFile(this.AssemblyPath.ItemSpec);
-                var publicTypes = assembly.GetExportedTypes();
+                var assemblyPath = this.AssemblyPath.ItemSpec;
 
-                var addinTypes = new List<TaskItem>();
-                var registryWrites = new List<TaskItem>();
+                var assembly = AssemblyEx.ReflectionOnlyLoadAssembly(assemblyPath);
+                var publicTypes = assembly.GetExportedTypes();
 
                 foreach (var publicType in publicTypes)
                 {
@@ -51,6 +48,7 @@ namespace NetOffice.Build
                             foreach (var officeAppItem in this.OfficeApps)
                             {
                                 var officeApp = officeAppItem.ItemSpec;
+                                Log.LogMessage(MessageImportance.High, $@"Cleaning add-in {progId} from Microsoft Office application {officeApp}");
                                 comClass.DeleteOfficeAddin(officeApp, progId);
                             }
                         }

--- a/src/RegisterAddin.cs
+++ b/src/RegisterAddin.cs
@@ -30,9 +30,9 @@ namespace NetOffice.Build
                 var assemblyPath = this.AssemblyPath.ItemSpec;
                 var assemblyDir = Path.GetDirectoryName(assemblyPath);
 
-                AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += (sender, args) => ReflectionOnlyAssemblyResolve(args, assemblyDir);
+                AppDomain.CurrentDomain.ReflectionOnlyAssemblyResolve += (sender, args) => AssemblyEx.ReflectionOnlyAssemblyResolve(args, assemblyDir);
 
-                var assembly = ReflectionOnlyLoadAssembly(assemblyPath);
+                var assembly = AssemblyEx.ReflectionOnlyLoadAssembly(assemblyPath);
                 var assemblyName = assembly.GetName();
                 var assemblyCodebase = assemblyPath.GetCodebase();
                 var publicTypes = assembly.GetExportedTypes();
@@ -64,7 +64,7 @@ namespace NetOffice.Build
                         Log.LogMessage(MessageImportance.High, $@"Registering {progId} class with guid {guid.ToRegistryString()}");
 
                         var comClass = new ComClassRegistry(this.Log);
-                        
+
                         var registeredKey = comClass.RegisterProgId(progId, guid);
                         if (registeredKey != null)
                         {
@@ -124,44 +124,6 @@ namespace NetOffice.Build
             }
 
             return true;
-        }
-
-        private static Assembly ReflectionOnlyLoadAssembly(string path)
-        {
-            if (File.Exists(path))
-            {
-                var assemblyName = AssemblyName.GetAssemblyName(path);
-                var assemblies = AppDomain.CurrentDomain.ReflectionOnlyGetAssemblies();
-                var existing = assemblies.FirstOrDefault(assembly => assembly.FullName == assemblyName.FullName);
-                if (existing != null)
-                {
-                    return existing;
-                }
-
-                var content = File.ReadAllBytes(path);
-                return Assembly.ReflectionOnlyLoad(content);
-            }
-
-            return null;
-        }
-
-        private Assembly ReflectionOnlyAssemblyResolve(ResolveEventArgs args, string baseDir)
-        {
-            Console.WriteLine($"Assembly: {args?.Name} by {args?.RequestingAssembly?.GetName()}");
-
-            var name = new AssemblyName(args.Name);
-            var path = Path.Combine(baseDir, name.Name + ".dll");
-            Assembly assembly = null;
-            if (File.Exists(path))
-            {
-                assembly = ReflectionOnlyLoadAssembly(path);
-            }
-            else
-            {
-                assembly = Assembly.ReflectionOnlyLoad(args.Name);
-            }
-
-            return assembly;
         }
     }
 }


### PR DESCRIPTION
Use reflection only assembly context when cleaning up add-ins

Fixes #6